### PR TITLE
Added nullable parameter handling for Android

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,17 @@
                 if(handleName === 'iOS') {
                     window.webkit.messageHandlers[funcName]["postMessage"](...safeArgs);
                 } else if(handleName === 'Android') {
-                    window[androidHandleName][funcName](...safeArgs);
+                    try {
+                        window[androidHandleName][funcName](...safeArgs);
+                    } catch(e) {
+                        console.warn(e);
+                        if(!safeArgs.length) {
+                            // Android does not like calling functions with invalid signature, eg. when parameter
+                            // is expected but you don't pass `null` explicitly. On the other hand, we need to
+                            // handle empty parameters as well.
+                            window[androidHandleName][funcName](null);
+                        }
+                    }
                 } else {
                     console.warn(`Handle not detected (tried to call "${funcName}" with args ${args} parsed as ${safeArgs})`);
                 }


### PR DESCRIPTION
There was a problem with initialization on Andorid. If "onGameIntialized" is expecting optional paremeter and no explicit "null" is passed, the communication will fail, failing all subsequent communications as well.